### PR TITLE
Broken deocumentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This starter kit provides a project foundation for building your own Headless CMS back-end using Enonic XP
 
-Complete documentation is available on https://developer.enonic.com/guides/headless-starter
+Complete documentation is available on https://developer.enonic.com/templates/headless-cms
 
 ## Quick test
 


### PR DESCRIPTION
updated broken link

The link goes to the guide how to use the starter. Not the starter documentation, that could be different?